### PR TITLE
maintenance: Fixed SeatService build, integration tests, github actions

### DIFF
--- a/.github/workflows/dev_container_build.yml
+++ b/.github/workflows/dev_container_build.yml
@@ -45,7 +45,7 @@ jobs:
 
       - id: repository-name-adjusted
         name: Prepare repository name in lower case for docker upload. This supports repository names in mixed case
-        uses: ASzc/change-string-case-action@v2
+        uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ github.repository }}
 

--- a/.github/workflows/dev_container_build.yml
+++ b/.github/workflows/dev_container_build.yml
@@ -35,7 +35,7 @@ on:
 
 jobs:
   build:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - name: adding github workspace as safe directory

--- a/.github/workflows/hvac_service.yml
+++ b/.github/workflows/hvac_service.yml
@@ -47,12 +47,12 @@ jobs:
 
       - id: repository-name-adjusted
         name: Make repository name in lower case for docker upload.
-        uses: ASzc/change-string-case-action@v2
+        uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ github.repository }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: "Build image"
         id: image_build

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -102,7 +102,7 @@ jobs:
             --log-file=./results/IntegrationTest/integration.log --log-file-level=DEBUG
 
       - name: Publish Integration Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: ./results/IntegrationTest/junit.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.github.io/flavors/
-        uses: megalinter/megalinter@v5
+        uses: megalinter/megalinter@v6
         env:
           # All available variables are described in documentation
           # https://megalinter.github.io/configuration/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.github.io/flavors/
-        uses: megalinter/megalinter@v6
+        uses: megalinter/megalinter@v5
         env:
           # All available variables are described in documentation
           # https://megalinter.github.io/configuration/
@@ -81,7 +81,7 @@ jobs:
       - name: Create Pull Request with applied fixes
         id: cpr
         if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: peter-evans/create-pull-request@v4.0.4
+        uses: peter-evans/create-pull-request@v4.2.3
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           commit-message: "[MegaLinter] Apply linters automatic fixes"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,8 @@ on:
 
 env: # Comment env block if you do not want to apply fixes
   # Apply linter fixes configuration
-  APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
-  APPLY_FIXES_EVENT: all # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
+  # APPLY_FIXES: all # When active, APPLY_FIXES must also be defined as environment variable (in github/workflows/mega-linter.yml or other CI tool)
+  APPLY_FIXES_EVENT: none # Decide which event triggers application of fixes in a commit or a PR (pull_request, push, all)
   APPLY_FIXES_MODE: commit # If APPLY_FIXES is used, defines if the fixes are directly committed (commit) or posted in a PR (pull_request)
   DEFAULT_BRANCH: main
   #TODO: Enable the following DOCKERFILE_DOCKERFILELINT, DOCKERFILE_HADOLINT, ACTION_ACTIONLINT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        #run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
         uses: actions/download-artifact@v3
@@ -63,7 +64,7 @@ jobs:
     steps:
       - id: repository-name-adjusted
         name: Prepare repository name in lower case for docker upload. This supports repository names in mixed case
-        uses: ASzc/change-string-case-action@v2
+        uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ github.repository }}
 
@@ -102,7 +103,7 @@ jobs:
     steps:
       - id: repository-name-adjusted
         name: Prepare repository name in lower case for docker upload. This supports repository names in mixed case
-        uses: ASzc/change-string-case-action@v2
+        uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ github.repository }}
 

--- a/.github/workflows/release_prepare.yml
+++ b/.github/workflows/release_prepare.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   bump-vdb-version:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
       - name: adding github workspace as safe directory

--- a/.github/workflows/scripts/install-ci-tooling.sh
+++ b/.github/workflows/scripts/install-ci-tooling.sh
@@ -45,10 +45,11 @@ sudo apt-get -qqy install \
 [ -z "$(which pip3)" ] && sudo apt-get -qqy install --fix-missing python3-pip
 
 # conan: dependency management
-# conan needed > 1.43 for gtest
+# - conan needed > 1.43 for gtest
+# - conan >= 2.0 breaks commandline interface
 # cantools: code generation from .dbc file
 pip3 install \
-	'conan==1.55.0' \
+	'conan==1.56.0' \
 	'cantools==37.0.1'
 
 # install docker

--- a/.github/workflows/scripts/install-ci-tooling.sh
+++ b/.github/workflows/scripts/install-ci-tooling.sh
@@ -40,7 +40,6 @@ sudo apt-get -qqy install \
 	cppcheck \
 	valgrind
 
-
 # Install PIP
 [ -z "$(which pip3)" ] && sudo apt-get -qqy install --fix-missing python3-pip
 

--- a/.github/workflows/seat_service_build.yml
+++ b/.github/workflows/seat_service_build.yml
@@ -23,7 +23,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # reduce runtime requirements from libc/libc++
+    runs-on: ubuntu-20.04
     name: Build
     strategy:
       matrix:

--- a/.github/workflows/seat_service_docu_build.yml
+++ b/.github/workflows/seat_service_docu_build.yml
@@ -23,7 +23,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # reduce runtime requirements from libc/libc++
+    runs-on: ubuntu-20.04
     name: Build docu
 
     steps:

--- a/.github/workflows/seat_service_release.yml
+++ b/.github/workflows/seat_service_release.yml
@@ -24,7 +24,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # reduce runtime requirements from libc/libc++
+    runs-on: ubuntu-20.04
     name: Build
     strategy:
       matrix:

--- a/.github/workflows/seat_service_release.yml
+++ b/.github/workflows/seat_service_release.yml
@@ -88,12 +88,12 @@ jobs:
 
       - id: repository-name-adjusted
         name: Make repository name in lower case for docker upload.
-        uses: ASzc/change-string-case-action@v2
+        uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ github.repository }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: "Build seat service image"
         id: image_build

--- a/.github/workflows/seat_service_seatctrl_test.yml
+++ b/.github/workflows/seat_service_seatctrl_test.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
 
       - name: cobertura-report
-        uses: 5monkeys/cobertura-action@v12
+        uses: 5monkeys/cobertura-action@v13
         with:
           path: ${{github.workspace}}/seat_service/build_seat_controller/x86_64/report_codecov_vservice-seat-ctrl.xml
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/seat_service_seatctrl_test.yml
+++ b/.github/workflows/seat_service_seatctrl_test.yml
@@ -28,7 +28,8 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # reduce runtime requirements from libc/libc++
+    runs-on: ubuntu-20.04
     name: Build
     steps:
       - name: adding github workspace as safe directory

--- a/.vscode/scripts/run-databroker-cli.sh
+++ b/.vscode/scripts/run-databroker-cli.sh
@@ -27,10 +27,12 @@ if [ -z "$DATABROKER_VERSION" ]; then
 	exit 1
 fi
 
-DATABROKER_BINARY_NAME="databroker_$PROCESSOR.tar.gz"
-DATABROKER_BINARY_PATH="$ROOT_DIRECTORY/.vscode/scripts/assets/databroker/$DATABROKER_VERSION/$PROCESSOR"
+# https://github.com/eclipse/kuksa.val/releases/download/0.3.0/databroker-cli-amd64.tar.gz
+
+DATABROKER_BINARY_NAME="databroker-cli-$PROCESSOR_ALT.tar.gz"
+DATABROKER_BINARY_PATH="$ROOT_DIRECTORY/.vscode/scripts/assets/databroker/$DATABROKER_VERSION/$PROCESSOR_ALT"
 DOWNLOAD_URL="https://github.com/eclipse/kuksa.val/releases/download/$DATABROKER_VERSION/$DATABROKER_BINARY_NAME"
-DATABROKERCLI_EXECUTABLE="$DATABROKER_BINARY_PATH/target/release/databroker-cli"
+DATABROKERCLI_EXECUTABLE="$DATABROKER_BINARY_PATH/databroker-cli/databroker-cli"
 
 download_release "$DATABROKERCLI_EXECUTABLE" "$DOWNLOAD_URL" "$DATABROKER_BINARY_PATH" "$DATABROKER_BINARY_NAME" || exit 1
 

--- a/.vscode/scripts/run-databroker.sh
+++ b/.vscode/scripts/run-databroker.sh
@@ -40,9 +40,10 @@ if [ -z "$DATABROKER_VERSION" ]; then
 	exit 1
 fi
 
-DATABROKER_BINARY_NAME="databroker_$PROCESSOR.tar.gz"
-DATABROKER_BINARY_PATH="$ROOT_DIRECTORY/.vscode/scripts/assets/databroker/$DATABROKER_VERSION/$PROCESSOR"
-DATABROKER_EXECUTABLE="$DATABROKER_BINARY_PATH/target/release/databroker"
+# https://github.com/eclipse/kuksa.val/releases/download/0.3.0/databroker-amd64.tar.gz
+DATABROKER_BINARY_NAME="databroker-$PROCESSOR_ALT.tar.gz"
+DATABROKER_BINARY_PATH="$ROOT_DIRECTORY/.vscode/scripts/assets/databroker/$DATABROKER_VERSION/$PROCESSOR_ALT"
+DATABROKER_EXECUTABLE="$DATABROKER_BINARY_PATH/databroker/databroker"
 DOWNLOAD_URL="https://github.com/eclipse/kuksa.val/releases/download/$DATABROKER_VERSION/$DATABROKER_BINARY_NAME"
 
 download_release "$DATABROKER_EXECUTABLE" "$DOWNLOAD_URL" "$DATABROKER_BINARY_PATH" "$DATABROKER_BINARY_NAME" || exit 1
@@ -50,7 +51,9 @@ download_release "$DATABROKER_EXECUTABLE" "$DOWNLOAD_URL" "$DATABROKER_BINARY_PA
 ### Data Broker environment setup ###
 
 ## Uncomment for feed values debug
-#export RUST_LOG="info,databroker=debug,vehicle_data_broker=debug"
+export RUST_LOG="debug,databroker=debug,vehicle_data_broker=debug,h2=info"
+##export GRPC_TRACE=all,-timer,-timer_check
+##export GRPC_VERBOSITY=DEBUG
 
 ## Uncomment to preregister vehicle model metadata in vss.json
 #DATABROKER_METADATA="--metadata $ROOT_DIRECTORY/.vscode/scripts/vss.json"

--- a/.vscode/scripts/run-databroker.sh
+++ b/.vscode/scripts/run-databroker.sh
@@ -56,7 +56,13 @@ export RUST_LOG="debug,databroker=debug,vehicle_data_broker=debug,h2=info"
 ##export GRPC_VERBOSITY=DEBUG
 
 ## Uncomment to preregister vehicle model metadata in vss.json
-#DATABROKER_METADATA="--metadata $ROOT_DIRECTORY/.vscode/scripts/vss.json"
+DATABROKER_METADATA="--metadata $DATABROKER_BINARY_PATH/vss.json"
+
+### handle vss json
+if [ -n "$DATABROKER_METADATA" ] && [ ! -f $DATABROKER_BINARY_PATH/vss.json ]; then
+	echo "# Downloading $DATABROKER_BINARY_PATH/vss.json ..."
+	wget -q "https://raw.githubusercontent.com/eclipse/kuksa.val/master/data/vss-core/vss_release_3.0.json" -O "$DATABROKER_BINARY_PATH/vss.json"
+fi
 
 echo
 echo "*******************************************"

--- a/.vscode/scripts/run-integrationtest.sh
+++ b/.vscode/scripts/run-integrationtest.sh
@@ -41,8 +41,10 @@ pip3 install -q -e "${ROOT_DIRECTORY}/hvac_service/"
 
 set +e
 
+REBUILD=1
+
 if [ "$USE_DAPR" = "0" ]; then
-	if true; then
+	if [ "$REBUILD" = "1" ]; then
 		echo "Rebuilding pre-release tags for seat and hvac services..."
 		export SEAT_TAG="prerelease"
 		export HVAC_TAG="prerelease"

--- a/.vscode/scripts/run-kuksa-cli.sh
+++ b/.vscode/scripts/run-kuksa-cli.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#********************************************************************************
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License 2.0 which is available at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+#*******************************************************************************/
+# shellcheck disable=SC2002
+
+echo "#######################################################"
+echo "### Running KUKSA CLI                          ###"
+echo "#######################################################"
+
+ROOT_DIRECTORY=$(git rev-parse --show-toplevel)
+# shellcheck source=/dev/null
+source "$ROOT_DIRECTORY/.vscode/scripts/task-common.sh" "$@"
+
+echo
+echo "Seat Service examples:"
+echo "  getMetaData Vehicle.Cabin.Seat.Row1.Pos1.Position"
+echo "  setTargetValue Vehicle.Cabin.Seat.Row1.Pos1.Position 200"
+echo
+
+# set to 1 to use pypy kuksa-val package
+STANDALONE=0
+if [ "$STANDALONE" = "1" ]; then
+	echo "# Installing kuksa-client..."
+	pip3 install -U kuksa-client
+
+	# prevent warning dumps
+	GRPC_ENABLE_FORK_SUPPORT=true kuksa-client --ip 127.0.0.1 --port "$DATABROKER_PORT" --protocol grpc --insecure
+else
+	docker run -it --rm -e GRPC_ENABLE_FORK_SUPPORT=true --net=host ghcr.io/eclipse/kuksa.val/kuksa-client:0.3.0 --ip 127.0.0.1 --port "$DATABROKER_PORT" --protocol grpc --insecure
+fi

--- a/.vscode/scripts/run-seatservice.sh
+++ b/.vscode/scripts/run-seatservice.sh
@@ -31,6 +31,7 @@ source "$ROOT_DIRECTORY/.vscode/scripts/task-common.sh" "$@"
 # export VEHICLEDATABROKER_DAPR_APP_ID="vehicledatabroker"
 
 # NOTE: use dapr sidecar's grpc port, don't connect directly to sidecar of vdb (DATABROKER_GRPC_PORT)
+
 export DAPR_GRPC_PORT=$SEATSERVICE_GRPC_PORT
 
 build_seatservice() {
@@ -63,8 +64,17 @@ export SAE_STOP=0
 # DataBrokerFeeder Debug level (0, 1, 2)
 export DBF_DEBUG=0
 
+### Uncomment for DEBUG
+export SA_DEBUG=2
+export DBF_DEBUG=3
+export SEAT_DEBUG=1
+
 # needed to override vdb address
 export BROKER_ADDR="127.0.0.1:$DAPR_GRPC_PORT"
+
+### Uncomment for direct connection to databroker
+# export GRPC_TRACE=all,-timer,-timer_check
+# export GRPC_VERBOSITY=DEBUG
 
 echo
 echo "*******************************************"
@@ -72,6 +82,7 @@ echo "* Seat Service app-id: $SEATSERVICE_DAPR_APP_ID"
 echo "* Seat Service APP port: $SEATSERVICE_PORT"
 echo "* Seat Service Dapr sidecar port: $SEATSERVICE_GRPC_PORT"
 echo "* DAPR_GRPC_PORT=$DAPR_GRPC_PORT"
+echo "* BROKER_ADDR=$BROKER_ADDR"
 echo "* metadata: [ VEHICLEDATABROKER_DAPR_APP_ID=$VEHICLEDATABROKER_DAPR_APP_ID ]"
 echo "*******************************************"
 echo

--- a/.vscode/scripts/task-common.sh
+++ b/.vscode/scripts/task-common.sh
@@ -86,7 +86,7 @@ download_release() {
 		return 0
 	fi
 	echo "- Downloading from: $download_url"
-	curl -o "$binary_path/$binary_name" --create-dirs -L -H "Accept: application/octet-stream" "$download_url"
+	curl -s -o "$binary_path/$binary_name" --create-dirs -L -H "Accept: application/octet-stream" "$download_url"
 	echo
 	echo "- downloaded: $(file $binary_path/$binary_name)"
 
@@ -120,9 +120,12 @@ _check_prerequisite
 if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
 	echo "- Detected AArch64 architecture"
 	PROCESSOR="aarch64"
+	PROCESSOR_ALT="arm64"
 else
 	echo "- Detected x86_64 architecture"
 	PROCESSOR="x86_64"
+	PROCESSOR_ALT="amd64"
 fi
 echo
 export PROCESSOR
+export PROCESSOR_ALT

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -218,6 +218,23 @@
       }
     },
     {
+      "label": "run-kuksa-cli",
+      // "detail": "Runs Kuksa Client",
+      "dependsOrder": "sequence",
+      "type": "shell",
+      "command": "./.vscode/scripts/run-kuksa-cli.sh",
+      "group": "test",
+      "isBackground": false,
+      "runOptions": {
+        "instanceLimit": 1
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "showReuseMessage": false
+      }
+    },
+    {
       "label": "Start VAL",
       "dependsOn": [
         // "Clean VAL binaries",

--- a/integration_test/test_val_seat.py
+++ b/integration_test/test_val_seat.py
@@ -67,7 +67,7 @@ async def test_vdb_metadata_get(setup_helper: VDBHelper) -> None:
     name = os.getenv("TEST_NAME", "Vehicle.Cabin.Seat.Row1.Pos1.Position")
 
     meta = await helper.get_vdb_metadata()
-    logger.debug("# get_vdb_metadata() -> \n{}".format(str(meta).replace('\n', ' ')))
+    logger.debug("# get_vdb_metadata() -> \n{}".format(str(meta).replace("\n", " ")))
 
     assert len(meta) > 0, "VDB Metadata is empty"  # nosec B101
     meta_list = helper.vdb_metadata_to_json(meta)

--- a/integration_test/test_val_seat.py
+++ b/integration_test/test_val_seat.py
@@ -67,7 +67,7 @@ async def test_vdb_metadata_get(setup_helper: VDBHelper) -> None:
     name = os.getenv("TEST_NAME", "Vehicle.Cabin.Seat.Row1.Pos1.Position")
 
     meta = await helper.get_vdb_metadata()
-    # logger.debug("# get_vdb_metadata() -> \n{}".format(str(meta).replace('\n', ' ')))
+    logger.debug("# get_vdb_metadata() -> \n{}".format(str(meta).replace('\n', ' ')))
 
     assert len(meta) > 0, "VDB Metadata is empty"  # nosec B101
     meta_list = helper.vdb_metadata_to_json(meta)
@@ -82,7 +82,7 @@ async def test_vdb_metadata_get(setup_helper: VDBHelper) -> None:
     logger.info("Found metadata: {}".format(name_reg))
 
     assert (  # nosec B101
-        name_reg["data_type"] == DataType.UINT32
+        name_reg["data_type"] == DataType.UINT16
     ), "{} datatype is {}".format(name, name_reg["data_type"])
     await helper.close()
 

--- a/prerequisite_settings.json
+++ b/prerequisite_settings.json
@@ -1,9 +1,12 @@
 {
   "databroker": {
-    "version": "databroker-v0.17.0",
-    "imageVersion": "v0.17.0"
+    "version": "0.3.0",
+    "imageVersion": "master"
   },
   "feedercan": {
     "version": "v0.1.0"
+  },
+  "kuksa_client": {
+    "version": "0.3.0"
   }
 }

--- a/seat_service/build-debug.sh
+++ b/seat_service/build-debug.sh
@@ -12,10 +12,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #*******************************************************************************/
 
+# shellcheck disable=SC2046
+
 # Specify:
 #   first argument: TARGET_ARCH = "x86_64" or "aarch64"; default: "x86_64"
 #   second argument: TARGET_ARCH = "<string>; default: "$SCRIPT_DIR/target/$TARGET_ARCH/Debug"
-
 set -ex
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/seat_service/build-debug.sh
+++ b/seat_service/build-debug.sh
@@ -17,7 +17,7 @@
 # Specify:
 #   first argument: TARGET_ARCH = "x86_64" or "aarch64"; default: "x86_64"
 #   second argument: TARGET_ARCH = "<string>; default: "$SCRIPT_DIR/target/$TARGET_ARCH/Debug"
-set -ex
+set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/seat_service/build-debug.sh
+++ b/seat_service/build-debug.sh
@@ -27,12 +27,23 @@ BUILD_DIR="$2"
 [ -z "$BUILD_DIR" ] && BUILD_DIR="$SCRIPT_DIR"/target/"$TARGET_ARCH"/debug
 
 cmake -E make_directory "$BUILD_DIR"
+
+# install last known good boost version before conan v2 mess...
+### experimental stuff
+export CONAN_REVISIONS_ENABLED=1
+echo "###############################"
+conan --version
+echo "########## Conan Info #########"
+conan info .
+echo "###############################"
+
 # build with dependencies of build_type Release
 conan install -if="$BUILD_DIR" --build=missing --profile:build=default --profile:host="${SCRIPT_DIR}/toolchains/target_${TARGET_ARCH}_Release" "$SCRIPT_DIR"
+
 cd "$BUILD_DIR" || exit
 # shellcheck disable=SC1091
 source activate.sh # Set environment variables for cross build
 cmake "$SCRIPT_DIR" -DCMAKE_BUILD_TYPE=Debug -DSDV_COVERAGE=ON -DSDV_BUILD_TESTING=ON -DCONAN_CMAKE_SILENT_OUTPUT=ON -DCMAKE_INSTALL_PREFIX="./install"
 sleep 1
-cmake --build . -j
+cmake --build . -j $(nproc)
 cmake --install .

--- a/seat_service/build-release.sh
+++ b/seat_service/build-release.sh
@@ -18,8 +18,6 @@
 
 # shellcheck disable=SC2086
 # shellcheck disable=SC2230
-#set -x
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 TARGET_ARCH="$1"
@@ -28,11 +26,23 @@ TARGET_ARCH="$1"
 BUILD_DIR="$2"
 [ -z "$BUILD_DIR" ] && BUILD_DIR="$SCRIPT_DIR/target/$TARGET_ARCH/release"
 
+# set -e
 cmake -E make_directory "$BUILD_DIR"
+
+# install last known good boost version before conan v2 mess...
+### experimental stuff
+export CONAN_REVISIONS_ENABLED=1
+
+### IMPORTANT: not compatible with conan-2.0
+echo "###############################"
+conan --version
+echo "########## Conan Info #########"
+conan info .
+echo "###############################"
+
 conan install -if="$BUILD_DIR" --build=missing --profile:build=default --profile:host="${SCRIPT_DIR}/toolchains/target_${TARGET_ARCH}_Release" "$SCRIPT_DIR"
 
-set -e
-cd "$BUILD_DIR"
+cd "$BUILD_DIR" || exit
 # shellcheck disable=SC1091
 
 source ./activate.sh # Set environment variables for cross build
@@ -40,7 +50,7 @@ source ./activate.sh # Set environment variables for cross build
 #CMAKE_CXX_FLAGS_RELEASE="${CMAKE_CXX_FLAGS_RELEASE} -s"
 cmake -DCMAKE_BUILD_TYPE=Release -DSDV_BUILD_TESTING=OFF -DCONAN_CMAKE_SILENT_OUTPUT=ON -DCMAKE_INSTALL_PREFIX="./install" "$SCRIPT_DIR"
 
-cmake --build . -j
+cmake --build . -j $(nproc)
 cmake --install .
 set +e
 

--- a/seat_service/build-release.sh
+++ b/seat_service/build-release.sh
@@ -18,6 +18,7 @@
 
 # shellcheck disable=SC2086
 # shellcheck disable=SC2230
+# shellcheck disable=SC2046
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 TARGET_ARCH="$1"

--- a/seat_service/conanfile.txt
+++ b/seat_service/conanfile.txt
@@ -13,8 +13,8 @@
 #*******************************************************************************/
 
 [requires]
+grpc/1.38.0@#a93eb68eaa39bd69ddb2c0d85e6eb490
 gtest/1.10.0
-grpc/1.38.0
 
 [build_requires]
 grpc/1.38.0 # Is needed in the build context to run generate code from proto files

--- a/seat_service/docker-build.sh
+++ b/seat_service/docker-build.sh
@@ -131,9 +131,10 @@ cd "$CONTEXT_DIR" || exit 1
 echo "# docker buildx build $DOCKER_ARGS --f seat_service/Dockerfile $CONTEXT_DIR"
 DOCKER_BUILDKIT=1 docker buildx build $DOCKER_ARGS -f seat_service/Dockerfile "$CONTEXT_DIR" $DOCKER_EXT
 
-if [ $? -eq 0 ]; then
+if [ "$DOCKER_ARCH" != "multiarch" ]; then
 	echo "docker image tag $DOCKER_ARCH/$DOCKER_IMAGE ghcr.io/eclipse/kuksa.val.services/$DOCKER_IMAGE:prerelease"
 	docker image tag $DOCKER_ARCH/$DOCKER_IMAGE ghcr.io/eclipse/kuksa.val.services/$DOCKER_IMAGE:prerelease
-	echo "# Exported $DOCKER_ARCH/$DOCKER_IMAGE in $DOCKER_EXPORT"
-	docker image ls | grep "/$DOCKER_IMAGE"
 fi
+
+echo "# Exported $DOCKER_ARCH/$DOCKER_IMAGE in $DOCKER_EXPORT"
+docker image ls | grep "/$DOCKER_IMAGE"

--- a/seat_service/src/bin/seat_service/main.cc
+++ b/seat_service/src/bin/seat_service/main.cc
@@ -99,7 +99,7 @@ void Run(std::string can_if_name, std::string listen_address, std::string port, 
 
     // Setup target actuator subscriber
     sdv::seat_service::SeatPositionSubscriber seat_position_subscriber(seat_adjuster, client);
-    std::cout << SELF "Start seat position subscription" << broker_addr << std::endl;
+    std::cout << SELF "Start seat position subscription " << broker_addr << std::endl;
 
     std::thread subscriber_thread(&sdv::seat_service::SeatPositionSubscriber::Run, &seat_position_subscriber);
 

--- a/seat_service/src/bin/seat_service/seat_data_feeder.cc
+++ b/seat_service/src/bin/seat_service/seat_data_feeder.cc
@@ -44,17 +44,17 @@ SeatDataFeeder::SeatDataFeeder(std::shared_ptr<SeatAdjuster> seat_adjuster, std:
     std::string seat_pos_name = "Vehicle.Cabin.Seat.Row1.Pos1.Position";
     sdv::broker_feeder::DatapointConfiguration metadata = {
         {"Vehicle.Cabin.SeatRowCount",
-            DataType::UINT32,
+            DataType::UINT16, // Changed from UINT32 to match VSS 3.0
             ChangeType::STATIC,
             broker_feeder::createDatapoint(1U),
             "Number of rows of seats"},
         {"Vehicle.Cabin.Seat.Row1.PosCount",
-            DataType::UINT32,
+            DataType::UINT8, // Changed from UINT32 to match VSS 3.0
             ChangeType::STATIC,
             broker_feeder::createDatapoint(1U),
             "Number of seats in row 1"},
         {seat_pos_name,
-            DataType::UINT32,
+            DataType::UINT8, // Changed from UINT32 to match VSS 3.0
             ChangeType::ON_CHANGE,
             broker_feeder::createNotAvailableValue(),
             "Longitudinal position of overall seat"}
@@ -72,6 +72,7 @@ SeatDataFeeder::SeatDataFeeder(std::shared_ptr<SeatAdjuster> seat_adjuster, std:
             std::cout << self << "got pos: " << position_in_percent << "%" << std::endl;
         }
         Datapoint datapoint;
+        // NOTE: we are using uint32 value as grpc does not have smaller integers
         if (0 <= position_in_percent && position_in_percent <= 100) {
             datapoint.set_uint32_value(position_in_percent * 10); // scale up to [0..1000]
         } else

--- a/seat_service/src/bin/seat_service/seat_position_subscriber.cc
+++ b/seat_service/src/bin/seat_service/seat_position_subscriber.cc
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "collector_client.h"
 #include "seat_adjuster.h"
@@ -82,8 +83,15 @@ void SeatPositionSubscriber::Run() {
                 }
             }
         }
+        grpc::Status status = reader->Finish();
+        if (status.ok()) {
+            std::cout << "SeatPositionSubscriber: disconnected." << std::endl;
+        } else {
+            std::cerr << "SeatPositionSubscriber: disconnected with status: " << subscriber_context_->debug_error_string() << std::endl;
+            // prevent busy polling if subscribe failed with error
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+        }
         subscriber_context_ = nullptr;
-        std::cout << "SeatPositionSubscriber: disconnected" << std::endl;
     }
     std::cout << "SeatPositionSubscriber: exiting" << std::endl;
 }

--- a/seat_service/src/bin/seat_service/seat_position_subscriber.cc
+++ b/seat_service/src/bin/seat_service/seat_position_subscriber.cc
@@ -69,7 +69,7 @@ void SeatPositionSubscriber::Run() {
                     switch (actuator_target.value_case()) {
                         case sdv::databroker::v1::Datapoint::ValueCase::kUint32Value: {
                             auto position = actuator_target.uint32();
-                            std::cout << "Got actuator target: " << position << std::endl;
+                            std::cout << "SeatPositionSubscriber: Got actuator target: " << position << std::endl;
                             if (position < 0 || 1000 < position) {
                                 std::cout << "Invalid position" << std::endl;
                                 continue;

--- a/seat_service/src/lib/broker_feeder/CMakeLists.txt
+++ b/seat_service/src/lib/broker_feeder/CMakeLists.txt
@@ -35,6 +35,12 @@ find_program(GRPC_CPP_PLUGIN_PROGRAM_ENV
 )
 get_filename_component(GRPC_CPP_PLUGIN_PROGRAM_ENV "${GRPC_CPP_PLUGIN_PROGRAM_ENV}" ABSOLUTE)
 
+message("--- [broker_feedder] Using protoc: ${PROTOC_PROGRAM_TEMP}")
+message("--- [broker_feedder] Using grpc_cpp_plugin: ${GRPC_CPP_PLUGIN_PROGRAM_ENV}")
+execute_process (
+  COMMAND "${PROTOC_PROGRAM_TEMP}" --version
+)
+
 add_library(data_broker_feeder
   STATIC
     data_broker_feeder.cc
@@ -89,7 +95,7 @@ protobuf_generate(
 )
 
 get_property(DB_FEEDER_INCLUDE_DIRS TARGET data_broker_feeder PROPERTY INCLUDE_DIRECTORIES)
-message(INFO ${DB_FEEDER_INCLUDE_DIRS})
+# message("Using DB Feeder includes: ${DB_FEEDER_INCLUDE_DIRS}")
 
 target_link_libraries(data_broker_feeder
   PUBLIC

--- a/seat_service/src/lib/broker_feeder/data_broker_feeder.cc
+++ b/seat_service/src/lib/broker_feeder/data_broker_feeder.cc
@@ -74,7 +74,7 @@ private:
          * Once connection is present, it starts registering the data points (metadata)
          * with the broker and feeds the initial values (plus possible already stored values
          * to the broker.
-         * Afterwards it is forwarding values stored by the feeding medthods and trys
+         * Afterwards it is forwarding values stored by the feeding methods and tries
          * re-establishing a lost connection to the broker.
          */
         while (feeder_active_) {

--- a/seat_service/src/lib/broker_feeder/data_broker_feeder.cc
+++ b/seat_service/src/lib/broker_feeder/data_broker_feeder.cc
@@ -186,7 +186,7 @@ private:
             reg_data.set_data_type(metadata.data_type);
             reg_data.set_change_type(metadata.change_type);
             reg_data.set_description(metadata.description);
-            reg_data.
+            // TODO: set entry_type to Actuator
             request.mutable_list()->Add(std::move(reg_data));
         }
 

--- a/seat_service/src/lib/broker_feeder/data_broker_feeder.cc
+++ b/seat_service/src/lib/broker_feeder/data_broker_feeder.cc
@@ -55,7 +55,6 @@ private:
     google::protobuf::Map<std::string, DatapointId> id_map_;
 
     std::atomic<bool> feeder_active_;
-    std::string broker_addr_;
     std::mutex stored_values_mutex_;
     std::condition_variable feeder_thread_sync_;
 
@@ -80,7 +79,7 @@ private:
          */
         while (feeder_active_) {
             if (dbf_debug > 0) {
-                std::cout << "DataBrokerFeederImpl: Connecting to data broker [" << broker_addr_ << "] ..." << std::endl;
+                std::cout << "DataBrokerFeederImpl: Connecting to data broker ..." << std::endl;
             }
             auto deadline = std::chrono::system_clock::now() + std::chrono::seconds(5);
             client_->WaitForConnected(deadline);
@@ -187,6 +186,7 @@ private:
             reg_data.set_data_type(metadata.data_type);
             reg_data.set_change_type(metadata.change_type);
             reg_data.set_description(metadata.description);
+            reg_data.
             request.mutable_list()->Add(std::move(reg_data));
         }
 

--- a/seat_service/src/lib/seat_adjuster/seat_controller/CMakeLists.txt
+++ b/seat_service/src/lib/seat_adjuster/seat_controller/CMakeLists.txt
@@ -54,6 +54,11 @@ set(CANTOOLS_GENERATED_C "${CMAKE_CURRENT_BINARY_DIR}/generated/CAN.c")
 # Generated sources
 add_custom_target(cangen ALL DEPENDS "${CANTOOLS_GENERATED_C}" "${CANTOOLS_GENERATED_H}")
 
+message("--- cantools version:")
+execute_process (
+  COMMAND cantools --version
+)
+
 # generate c stubs from dbc
 message("--- Generating can C sources from: ${DBC_FILE}")
 add_custom_command(OUTPUT "${CANTOOLS_GENERATED_C}" "${CANTOOLS_GENERATED_H}"

--- a/seat_service/toolchains/target_aarch64_Debug
+++ b/seat_service/toolchains/target_aarch64_Debug
@@ -6,7 +6,7 @@ cxx_compiler=g++
 [settings]
 os=Linux
 compiler=gcc
-compiler.version=11
+compiler.version=9
 compiler.libcxx=libstdc++11
 
 arch=armv8

--- a/seat_service/toolchains/target_aarch64_Release
+++ b/seat_service/toolchains/target_aarch64_Release
@@ -6,7 +6,7 @@ cxx_compiler=g++
 [settings]
 os=Linux
 compiler=gcc
-compiler.version=11
+compiler.version=9
 compiler.libcxx=libstdc++11
 
 arch=armv8

--- a/seat_service/toolchains/target_x86_64_Debug
+++ b/seat_service/toolchains/target_x86_64_Debug
@@ -1,7 +1,7 @@
 [settings]
 os=Linux
 compiler=gcc
-compiler.version=11
+compiler.version=9
 compiler.libcxx=libstdc++11
 
 arch=x86_64

--- a/seat_service/toolchains/target_x86_64_Release
+++ b/seat_service/toolchains/target_x86_64_Release
@@ -1,7 +1,7 @@
 [settings]
 os=Linux
 compiler=gcc
-compiler.version=11
+compiler.version=9
 compiler.libcxx=libstdc++11
 
 arch=x86_64

--- a/seat_service/vscode-conan.sh
+++ b/seat_service/vscode-conan.sh
@@ -38,6 +38,9 @@ PROJ_DIR="$1"
 BUILD_DIR="$2"
 [ -z "$BUILD_DIR" ] && BUILD_DIR="$PROJ_DIR/build"
 
+# install last known good boost version before conan v2 mess...
+### experimental stuff
+export CONAN_REVISIONS_ENABLED=1
 conan install -if="$BUILD_DIR" --build=missing --profile:build=default --profile:host="$SCRIPT_DIR/toolchains/target_x86_64_Debug" "$SCRIPT_DIR"
 [ $? -ne 0 ] && echo "conan install failed!" && exit 1
 


### PR DESCRIPTION
Maintenance fixes:

- Seat Service
  - Build on ubuntu-20.04 for more compatible binaries, reverted conan compiler.version to 9
  - Added revisions for conan recipes and fixed conan version (>=2.0 is not compatible)
  - Dumps added to CMakeLists to help troubleshooting protoc versin errors
  - Added grpc status handling in SeatPositionSubscriber
  - Fixed registered seat service metadata types to match VSS 3.0 in databroker container

- Fixed integration test and vss type of service position
  - Added getting vss3.0 json from kulsa.val git in vscode databroker script
  - Fixed expected metadata type for Vehicle.Cabin.Seat.Row1.Pos1.Position

- Fixed vscode scritpts to work with recent kuksa.val releases, added kuksa client vscode wrapper task
- Disabled megalinter commits, fixed github action versions, cleaned up warnings

