### PR TITLE
Fix mock value trigger

### DIFF
--- a/mock_service/mockservice.py
+++ b/mock_service/mockservice.py
@@ -188,7 +188,6 @@ class MockService(BaseService):
             entry = SubscribeEntry(path=mocked_datapoint.path)
             if mocked_datapoint.data_type is not None:
                 entry.fields.append(Field.FIELD_ACTUATOR_TARGET)
-            else:
                 entry.fields.append(Field.FIELD_VALUE)
             request.entries.append(entry)
 


### PR DESCRIPTION
For actuator targets the EventTrigger worked fine. For an EventTrigger on a change of a value it didn't work because it didn't get the events from databroker. What I did is include the field "value" like the field "actuator_target".