### PR TITLE
extends documentation for vehicle mock service

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository contains examples of vservices and their implementations to show
 It currently consists of
 * a simple example [HVAC service](./hvac_service) written in Python and
 * a more complex example [seat control service](./seat_service) written in C/C++.
+* a [mock service](./mock_service/) written in Python to define execute mocking behavior defined in a Python-based DSL
   
 More elaborate or completely differing implementations are target of "real world grown" projects.
 

--- a/mock_service/README.md
+++ b/mock_service/README.md
@@ -1,11 +1,12 @@
-# Mock service
+# Vehicle Mock Service
 
 ## About
 
-The mock service is a service dummy allowing to control all specified actuators and signals via a configuration file.
+The vehicle mock service is a service dummy allowing to control all specified actuator- and sensor-signals via a configuration file. These configuration files are expressed in a Python-based [domain-specific language (DSL)](./doc/pydoc/mocking-dsl.md).
+
 ## Why
 
-When developing further services or vehicle applications, it can be very useful to be able to mock VSS actuators or sensors without developing a new service. Mock service provides developers with the ability to do just that. Have a look at the complete concept and design ideas [here](./doc/concept.md)
+When developing further vehicle applications, it can be very useful to be able to mock VSS actuators or sensors by specifying configuration files and without developing a new service from scratch. This vehicle mock service provides developers with the ability to do just that. Have a look at the complete concept and design ideas [here](./doc/concept.md)
 
 ## Component diagram
 
@@ -14,42 +15,14 @@ When developing further services or vehicle applications, it can be very useful 
 flowchart LR
     BrokerIF(( ))
     ValIF(( ))
-    DataBroker -- Broker IF ---- BrokerIF
-    DataBroker -- VAL IF ---- ValIF
-    BrokerIF<---->MockService
-    ValIF<---->MockService
-    BrokerIF<---->VApp
+    ServiceIF(( ))
+    id1[KUKSA.val databroker] -- sdv.databroker.v1 --- BrokerIF
+    ServiceIF -- kuksa.val.v1 --- id1
+    id1 -- kuksa.val.v1 --- ValIF
+    id2[Vehicle Mock Service] <--> ServiceIF
+    BrokerIF<--> id3[Vehicle App]
+    ValIF <--> id3
 ```
-
-## Configuration
-
-### Server
-
-| parameter      | default value         | Env var                                                                          | description                     |
-|----------------|-----------------------|----------------------------------------------------------------------------------|---------------------------------|
-| listen_address | `"127.0.0.1:50053"`   | `MOCK_ADDR`                                                                      | Listen for rpc calls            |
-| broker_address | `"127.0.0.1:55555"`   | `"127.0.0.1:$DAPR_GRPC_PORT"` (if DAPR_GRPC_PORT is set)<br>`VDB_ADDRESS` (else) | Connect to data broker instance |
-| broker_app_id  | `"vehicledatabroker"` | `VEHICLEDATABROKER_DAPR_APP_ID`                                                  | Connect to data broker instance |
-
-Configuration options have the following priority (highest at top):
-1. environment variable
-2. default value
-
-## Mock configuration
-
-Mocked datapoint configuration is read from the `mock.py` Python file at runtime. The built container image contains a default configuration for
-* `Vehicle.Speed`
-* `Vehicle.Cabin.Seat.Row1.Pos1.Position`
-* `Vehicle.Body.Windshield.Front.Wiping.System.Mode`
-* `Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition`
-* `Vehicle.Body.Windshield.Front.Wiping.System.ActualPosition`
-
-This allows the mock service to be used with the [Velocitas Seat Adjuster](https://eclipse.dev/velocitas/docs/about/use_cases/seat_adjuster/) example, as well as the initial [Vehicle App template](https://github.com/eclipse-velocitas/vehicle-app-python-template). Furthermore, it can be used to develop a wiping application for the front wipers.
-
-### Custom mocking configuration
-If the mocked datapoints are not enough, the `mock.py` in this repository can be modified and mounted into the mock service container - it will then overwrite the default mock configuration with the custom one.
-
-The full Python mocking DSL can be found [here](./doc/pydoc/mocking-dsl.md)
 
 # Running mockservice
 
@@ -59,11 +32,51 @@ Firstly, you will need to install all necessary Python dependencies by issuing t
 python3 -m pip install -r ./requirements.txt
 ```
 
-To run mock service, use the provided VSCode task `run-mockservice` which will set up all necessary environment variables and parameters for the service to start up properly.
+You can then run the vehicle mock service with
+
+```bash
+python3 mockservice.py
+```
+
+As an alternative, you can build and execute the container from the [Dockerfile](./Dockerfile) or through the [docker-build.sh](./docker-build.sh) script.
+
+Another option, when using VS Code, is to use the [provided VSCode task](../.vscode/tasks.json) `run-mockservice` which will set up all necessary environment variables and parameters for the service to start up properly.
+
+## Configuration
+
+### Vehicle Mock Service
+
+| parameter      | default value         | Environment variable               | description                     |
+|----------------|-----------------------|----------------------------------------------------------------------------------|---------------------------------|
+| listen address | `"127.0.0.1:50053"`   | `MOCK_ADDR`                                                                      | Listen for rpc calls            |
+| broker address | `"127.0.0.1:55555"`   | if DAPR_GRPC_PORT is set:<br>`"127.0.0.1:$DAPR_GRPC_PORT"` <br>else:<br> `VDB_ADDRESS`| The address of the KUKSA.val databroker to connect to |
+| broker app id  | `"vehicledatabroker"` | `VEHICLEDATABROKER_DAPR_APP_ID`                                                  | When using DAPR, this allows to configure the id of the KUKSA.val databroker to connect to. |
+
+Configuration options have the following priority (highest at top):
+1. environment variable
+2. default value
+
+### Mocking Configuration
+
+By default, the vehicle mock service reads the configuration for the datapoints to mock from the [`mock.py`](./mock.py) Python file at runtime. This file is a good starting point edit own mock configurations. 
+
+The default configuration contains behavior for:
+* `Vehicle.Speed`
+* `Vehicle.Cabin.Seat.Row1.Pos1.Position`
+* `Vehicle.Body.Windshield.Front.Wiping.System.Mode`
+* `Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition`
+* `Vehicle.Body.Windshield.Front.Wiping.System.ActualPosition`
+
+This allows the vehicle mock service to be used with the [Velocitas Seat Adjuster](https://eclipse.dev/velocitas/docs/about/use_cases/seat_adjuster/) example, as well as the initial [Vehicle App template](https://github.com/eclipse-velocitas/vehicle-app-python-template). Furthermore, it can be used to develop a wiping application for the front wipers.
+
+### Custom mocking configuration
+If the mocked datapoints are not enough, the `mock.py` in this repository can be modified and mounted into the vehicle mock service container - it will then overwrite the default mock configuration with the custom one.
+
+The full Python mocking DSL is available [here](./doc/pydoc/mocking-dsl.md)
 
 # Generating API documentation
 
-API documentation is generated from Python docs and embedded into markdown files for easy rendering on Github without external hosting. The workflow `ensure-docs-up2date` makes sure that the API docs are up to date before merging a pull request. To update the docs, run
+The [API documentation](./doc/pydoc/mocking-dsl.md) is generated from Python docs and embedded into markdown files for easy rendering on Github without external hosting. The workflow `ensure-docs-up2date` makes sure that the API docs are up to date before merging a pull request. To update the docs, run
 
 ```bash
 ./update-api-docs.sh


### PR DESCRIPTION
@doosuu, this PR extends the documentation for the vehicle mock service. Can you check whether the additions still reflect the state of the mock service? For instance, I am not sure whether the vehicle mock service actually uses the kuksa.val.v1 interface of the KUKSA.val databroker. The respective generated classes are part of the service but my IDE could not find any usage of this interface in the mock service. 